### PR TITLE
エラーメッセージ表示機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,8 @@ gem 'image_processing', '~> 1.2'
 
 gem 'payjp'
 
+gem 'rails-i18n'
+
 group :production do
   gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -311,6 +314,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 6.0.0)
+  rails-i18n
   rails_12factor
   rspec-rails (~> 4.0.0)
   rubocop

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -56,7 +56,4 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
     redirect_to action: :show if current_user.id != @item.user_id
   end
-
-  
-
 end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -5,6 +5,7 @@ class TransactionsController < ApplicationController
 
   def index
     @item = Item.find(params[:item_id])
+    @orderitem = OrderItem.new
   end
 
   def new
@@ -13,8 +14,10 @@ class TransactionsController < ApplicationController
 
   def create
     @orderitem = all_transaction_params
-    if @orderitem.save
+    @item = Item.find(params[:item_id])
+    if @orderitem.valid?
       pay_item
+      @orderitem.save
       redirect_to root_path
     else
       render 'index'

--- a/app/forms/order_item.rb
+++ b/app/forms/order_item.rb
@@ -8,8 +8,8 @@ class OrderItem
   month_year = /\A\d{2}\z/
   cvc_number = /\A\d{3,4}\z/
 
-  validates :postal_code, format: { with: include_hyphen, message: 'is invalid.Include hyphen(-).' }
-  validates :phone_number, format: { with: only_number, message: "is invalid.Don't include hyphen(-) or Phone number is within 11 digits." }
+  validates :postal_code, format: { with: include_hyphen, message: 'にはハイフン(-)を含めてください' }
+  validates :phone_number, format: { with: only_number, message: "にはハイフンを含めないでください" }
 
   with_options presence: true do
     validates :postal_code
@@ -19,7 +19,7 @@ class OrderItem
     validates :phone_number
   end
 
-  validates :prefecture_id, numericality: { other_than: 1 }
+  validates :prefecture_id, numericality: { other_than: 1, message: 'を選択してください' }
 
   def save
     Order.create(user_id: user_id, item_id: item_id)

--- a/app/forms/order_item.rb
+++ b/app/forms/order_item.rb
@@ -22,7 +22,7 @@ class OrderItem
   validates :prefecture_id, numericality: { other_than: 1 }
 
   def save
-    Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, address: address, building: building, phone_number: phone_number, item_id: item_id)
     Order.create(user_id: user_id, item_id: item_id)
+    Address.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, address: address, building: building, phone_number: phone_number, item_id: item_id)
   end
 end

--- a/app/forms/order_item.rb
+++ b/app/forms/order_item.rb
@@ -9,7 +9,7 @@ class OrderItem
   cvc_number = /\A\d{3,4}\z/
 
   validates :postal_code, format: { with: include_hyphen, message: 'にはハイフン(-)を含めてください' }
-  validates :phone_number, format: { with: only_number, message: "にはハイフンを含めないでください" }
+  validates :phone_number, format: { with: only_number, message: 'にはハイフンを含めないでください' }
 
   with_options presence: true do
     validates :postal_code

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -24,7 +24,7 @@ const pay = () => {
         document.getElementById("card-cvc").removeAttribute("name");
         document.getElementById("card-exp-month").removeAttribute("name");
         document.getElementById("card-exp-year").removeAttribute("name");
-
+       
         document.getElementById("charge-form").submit();
         document.getElementById("charge-form").reset();
       } else {

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,7 +19,7 @@ class Item < ApplicationRecord
     validates :explanation
   end
 
-  with_options presence: true, numericality: { other_than: 1 ,message: 'を選択してください'} do
+  with_options presence: true, numericality: { other_than: 1, message: 'を選択してください' } do
     validates :category_id
     validates :status_id
     validates :shipping_fee_id

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -19,7 +19,7 @@ class Item < ApplicationRecord
     validates :explanation
   end
 
-  with_options presence: true, numericality: { other_than: 1 } do
+  with_options presence: true, numericality: { other_than: 1 ,message: 'を選択してください'} do
     validates :category_id
     validates :status_id
     validates :shipping_fee_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,14 +16,14 @@ class User < ApplicationRecord
     validates :birthday
   end
 
-  validates :password, format: { with: alphanumeric, message: 'パスワードには英字と数字を混ぜてください' }
+  validates :password, format: { with: alphanumeric, message: 'には英字と数字を混ぜてください' }
 
-  with_options presence: true, format: { with: zenkaku, message: '全角文字を使用してください' } do
+  with_options presence: true, format: { with: zenkaku, message: 'には全角文字を使用してください' } do
     validates :second_name
     validates :first_name
   end
 
-  with_options presence: true, format: { with: katakana, message: '全角カタカナを使用してください' } do
+  with_options presence: true, format: { with: katakana, message: 'には全角カタカナを使用してください' } do
     validates :second_kana
     validates :first_kana
   end

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -31,7 +31,8 @@
     </div>
     <%# /支払額の表示 %>
 
-    <%= form_with model: @orderitem, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= form_with  url: item_transactions_path, id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%= render 'shared/error_messages', model: @orderitem %>
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ module Furima28400
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
 
+    # 日本語の言語設定
+    config.i18n.default_locale = :ja
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,142 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザ
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントは凍結されています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: アカウント登録もしくはログインしてください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: あなたのメール変更（%{email}）のお知らせいたします。
+        subject: メール変更完了。
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されたことを通知します。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントの凍結解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか?
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか?
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントが凍結されているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか?
+        didn_t_receive_unlock_instructions: アカウントの凍結解除方法のメールを受け取っていませんか?
+        forgot_your_password: パスワードを忘れましたか?
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントの凍結解除方法を再送する
+      send_instructions: アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントの凍結解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントを凍結解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: は凍結されていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,29 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        nickname: ニックネーム
+        birthday: 誕生日
+        second_name: 名
+        first_name: 姓
+        second_kana: 名
+        first_kana: 姓
+      item:
+        image: 画像
+        price: 価格
+        name: 商品名
+        explanation: 商品の説明
+        category_id: カテゴリー
+        status_id: 商品の状態
+        shipping_fee_id: 配送料の負担
+        shipping_area_id: 発送元の地域
+        days_until_shipping_id: 発送までの日数
+  activemodel:
+    attributes:
+      order_item:
+        postal_code: 郵便番号
+        prefecture_id: 都道府県
+        city: 市区町村
+        address: 番地
+        phone_number: 電話番号
+

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -8,6 +8,6 @@ FactoryBot.define do
     shipping_fee_id { 2 }
     shipping_area_id { 2 }
     days_until_shipping_id { 2 }
-    user_id { 1 }
+    association :user
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,57 +13,57 @@ RSpec.describe Item, type: :model do
     it 'nameが空では出品できないこと' do
       @item.name = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Name can't be blank")
+      expect(@item.errors.full_messages).to include("商品名を入力してください")
     end
     it 'priceが空では出品できないこと' do
       @item.price = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Price can't be blank")
+      expect(@item.errors.full_messages).to include("価格を入力してください")
     end
     it 'imageが空では出品できないこと' do
       @item.image = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank")
+      expect(@item.errors.full_messages).to include("画像を入力してください")
     end
     it 'explanationが空では出品できないこと' do
       @item.explanation = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("Explanation can't be blank")
+      expect(@item.errors.full_messages).to include("商品の説明を入力してください")
     end
     it 'category_idが1では出品できないこと' do
       @item.category_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Category must be other than 1')
+      expect(@item.errors.full_messages).to include('カテゴリーを選択してください')
     end
     it 'status_idが1では出品できないこと' do
       @item.status_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Status must be other than 1')
+      expect(@item.errors.full_messages).to include('商品の状態を選択してください')
     end
     it 'shipping_fee_idが1では出品できないこと' do
       @item.shipping_fee_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Shipping fee must be other than 1')
+      expect(@item.errors.full_messages).to include('配送料の負担を選択してください')
     end
     it 'shipping_area_idが1では出品できないこと' do
       @item.shipping_area_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Shipping area must be other than 1')
+      expect(@item.errors.full_messages).to include('発送元の地域を選択してください')
     end
     it 'days_until_shipping_idが1では出品できないこと' do
       @item.days_until_shipping_id = 1
       @item.valid?
-      expect(@item.errors.full_messages).to include('Days until shipping must be other than 1')
+      expect(@item.errors.full_messages).to include('発送までの日数を選択してください')
     end
     it 'priceが３００円以上であること' do
       @item.price = 200
       @item.valid?
-      expect(@item.errors.full_messages).to include('Price must be greater than 299')
+      expect(@item.errors.full_messages).to include('価格は299より大きい値にしてください')
     end
     it 'priceが９，９９９，９９９円以下であること' do
       @item.price = 100_000_000
       @item.valid?
-      expect(@item.errors.full_messages).to include('Price must be less than 10000000')
+      expect(@item.errors.full_messages).to include('価格は10000000より小さい値にしてください')
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -13,22 +13,22 @@ RSpec.describe Item, type: :model do
     it 'nameが空では出品できないこと' do
       @item.name = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("商品名を入力してください")
+      expect(@item.errors.full_messages).to include('商品名を入力してください')
     end
     it 'priceが空では出品できないこと' do
       @item.price = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("価格を入力してください")
+      expect(@item.errors.full_messages).to include('価格を入力してください')
     end
     it 'imageが空では出品できないこと' do
       @item.image = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("画像を入力してください")
+      expect(@item.errors.full_messages).to include('画像を入力してください')
     end
     it 'explanationが空では出品できないこと' do
       @item.explanation = nil
       @item.valid?
-      expect(@item.errors.full_messages).to include("商品の説明を入力してください")
+      expect(@item.errors.full_messages).to include('商品の説明を入力してください')
     end
     it 'category_idが1では出品できないこと' do
       @item.category_id = 1

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -12,22 +12,22 @@ RSpec.describe OrderItem, type: :model do
     it 'postal_codeが空だと保存ができないこと' do
       @order_item.postal_code = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("Postal code can't be blank")
+      expect(@order_item.errors.full_messages).to include("郵便番号を入力してください")
     end
     it 'prefecture_idが1だと保存ができないこと' do
       @order_item.prefecture_id = 1
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include('Prefecture must be other than 1')
+      expect(@order_item.errors.full_messages).to include('都道府県を選択してください')
     end
     it 'cityが空だと保存ができないこと' do
       @order_item.city = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("City can't be blank")
+      expect(@order_item.errors.full_messages).to include("市区町村を入力してください")
     end
     it 'addressが空だと保存ができないこと' do
       @order_item.address = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("Address can't be blank")
+      expect(@order_item.errors.full_messages).to include("番地を入力してください")
     end
     it 'buildingが空でも保存ができること' do
       @order_item.building = nil
@@ -36,22 +36,17 @@ RSpec.describe OrderItem, type: :model do
     it 'phone_numberが空だと保存ができないこと' do
       @order_item.phone_number = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("Phone number can't be blank")
+      expect(@order_item.errors.full_messages).to include("電話番号を入力してください")
     end
     it 'postal_codeにはハイフンが必要であること' do
       @order_item.postal_code = '1234567'
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include('Postal code is invalid.Include hyphen(-).')
+      expect(@order_item.errors.full_messages).to include('郵便番号にはハイフン(-)を含めてください')
     end
     it 'phone_numberにはハイフンが不要であること' do
       @order_item.phone_number = '090-1234-5678'
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("Phone number is invalid.Don't include hyphen(-) or Phone number is within 11 digits.")
-    end
-    it 'phone_numberは11桁以内であること' do
-      @order_item.phone_number = '090123456789'
-      @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("Phone number is invalid.Don't include hyphen(-) or Phone number is within 11 digits.")
+      expect(@order_item.errors.full_messages).to include("電話番号にはハイフンを含めないでください")
     end
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OrderItem, type: :model do
     it 'postal_codeが空だと保存ができないこと' do
       @order_item.postal_code = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("郵便番号を入力してください")
+      expect(@order_item.errors.full_messages).to include('郵便番号を入力してください')
     end
     it 'prefecture_idが1だと保存ができないこと' do
       @order_item.prefecture_id = 1
@@ -22,12 +22,12 @@ RSpec.describe OrderItem, type: :model do
     it 'cityが空だと保存ができないこと' do
       @order_item.city = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("市区町村を入力してください")
+      expect(@order_item.errors.full_messages).to include('市区町村を入力してください')
     end
     it 'addressが空だと保存ができないこと' do
       @order_item.address = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("番地を入力してください")
+      expect(@order_item.errors.full_messages).to include('番地を入力してください')
     end
     it 'buildingが空でも保存ができること' do
       @order_item.building = nil
@@ -36,7 +36,7 @@ RSpec.describe OrderItem, type: :model do
     it 'phone_numberが空だと保存ができないこと' do
       @order_item.phone_number = nil
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("電話番号を入力してください")
+      expect(@order_item.errors.full_messages).to include('電話番号を入力してください')
     end
     it 'postal_codeにはハイフンが必要であること' do
       @order_item.postal_code = '1234567'
@@ -46,7 +46,7 @@ RSpec.describe OrderItem, type: :model do
     it 'phone_numberにはハイフンが不要であること' do
       @order_item.phone_number = '090-1234-5678'
       @order_item.valid?
-      expect(@order_item.errors.full_messages).to include("電話番号にはハイフンを含めないでください")
+      expect(@order_item.errors.full_messages).to include('電話番号にはハイフンを含めないでください')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,48 +13,48 @@ RSpec.describe User, type: :model do
     it 'nicknameが空では登録できないこと' do
       @user.nickname = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("ニックネームを入力してください")
+      expect(@user.errors.full_messages).to include('ニックネームを入力してください')
     end
 
     it 'second_nameが空では登録できないこと' do
       @user.second_name = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("名を入力してください")
+      expect(@user.errors.full_messages).to include('名を入力してください')
     end
     it 'first_nameが空では登録できないこと' do
       @user.first_name = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("姓を入力してください")
+      expect(@user.errors.full_messages).to include('姓を入力してください')
     end
     it 'second_kanaが空では登録できないこと' do
       @user.second_kana = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("名を入力してください")
+      expect(@user.errors.full_messages).to include('名を入力してください')
     end
     it 'first_kanaが空では登録できないこと' do
       @user.first_kana = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("姓を入力してください")
+      expect(@user.errors.full_messages).to include('姓を入力してください')
     end
     it 'birthdayが空では登録できないこと' do
       @user.birthday = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("誕生日を入力してください")
+      expect(@user.errors.full_messages).to include('誕生日を入力してください')
     end
     it 'emailが空では登録できないこと' do
       @user.email = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Eメールを入力してください")
+      expect(@user.errors.full_messages).to include('Eメールを入力してください')
     end
     it 'passwordが空では登録できないこと' do
       @user.password = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("パスワードを入力してください")
+      expect(@user.errors.full_messages).to include('パスワードを入力してください')
     end
     it 'passwordが存在してもpassword_confirmationが空では登録できないこと' do
       @user.password_confirmation = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
+      expect(@user.errors.full_messages).to include('パスワード（確認用）とパスワードの入力が一致しません')
     end
 
     it 'emailに一意性があること' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,48 +13,48 @@ RSpec.describe User, type: :model do
     it 'nicknameが空では登録できないこと' do
       @user.nickname = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Nickname can't be blank")
+      expect(@user.errors.full_messages).to include("ニックネームを入力してください")
     end
 
     it 'second_nameが空では登録できないこと' do
       @user.second_name = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Second name can't be blank")
+      expect(@user.errors.full_messages).to include("名を入力してください")
     end
     it 'first_nameが空では登録できないこと' do
       @user.first_name = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("First name can't be blank")
+      expect(@user.errors.full_messages).to include("姓を入力してください")
     end
     it 'second_kanaが空では登録できないこと' do
       @user.second_kana = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Second kana can't be blank")
+      expect(@user.errors.full_messages).to include("名を入力してください")
     end
     it 'first_kanaが空では登録できないこと' do
       @user.first_kana = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("First kana can't be blank")
+      expect(@user.errors.full_messages).to include("姓を入力してください")
     end
     it 'birthdayが空では登録できないこと' do
       @user.birthday = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Birthday can't be blank")
+      expect(@user.errors.full_messages).to include("誕生日を入力してください")
     end
     it 'emailが空では登録できないこと' do
       @user.email = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Email can't be blank")
+      expect(@user.errors.full_messages).to include("Eメールを入力してください")
     end
     it 'passwordが空では登録できないこと' do
       @user.password = nil
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password can't be blank")
+      expect(@user.errors.full_messages).to include("パスワードを入力してください")
     end
     it 'passwordが存在してもpassword_confirmationが空では登録できないこと' do
       @user.password_confirmation = ''
       @user.valid?
-      expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password")
+      expect(@user.errors.full_messages).to include("パスワード（確認用）とパスワードの入力が一致しません")
     end
 
     it 'emailに一意性があること' do
@@ -62,42 +62,42 @@ RSpec.describe User, type: :model do
       another_user = FactoryBot.build(:user)
       another_user.email = @user.email
       another_user.valid?
-      expect(another_user.errors.full_messages).to include('Email has already been taken')
+      expect(another_user.errors.full_messages).to include('Eメールはすでに存在します')
     end
     it 'emailは@を含んでいること' do
       @user.email = 'aiueo'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Email is invalid')
+      expect(@user.errors.full_messages).to include('Eメールは不正な値です')
     end
     it 'passwordは６文字以上であること' do
       @user.password = 'abcde'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)')
+      expect(@user.errors.full_messages).to include('パスワードは6文字以上で入力してください')
     end
     it 'passwordは英数字混合であること' do
       @user.password = 'abcdef'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Password パスワードには英字と数字を混ぜてください')
+      expect(@user.errors.full_messages).to include('パスワードには英字と数字を混ぜてください')
     end
     it 'ユーザー本名（姓）は全角（漢字・ひらがな・カタカナ）であること' do
       @user.second_name = 'abcdef'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Second name 全角文字を使用してください')
+      expect(@user.errors.full_messages).to include('名には全角文字を使用してください')
     end
     it 'ユーザー本名（名）は全角（漢字・ひらがな・カタカナ）であること' do
       @user.first_name = 'abcdef'
       @user.valid?
-      expect(@user.errors.full_messages).to include('First name 全角文字を使用してください')
+      expect(@user.errors.full_messages).to include('姓には全角文字を使用してください')
     end
     it 'ユーザー本名（姓）のフリガナが全角（カタカナ）であること' do
       @user.second_kana = 'abcdef'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Second kana 全角カタカナを使用してください')
+      expect(@user.errors.full_messages).to include('名には全角カタカナを使用してください')
     end
     it 'ユーザー本名（名）のフリガナが全角（カタカナ）であること' do
       @user.first_kana = 'abcdef'
       @user.valid?
-      expect(@user.errors.full_messages).to include('First kana 全角カタカナを使用してください')
+      expect(@user.errors.full_messages).to include('姓には全角カタカナを使用してください')
     end
   end
 end


### PR DESCRIPTION
#What
入力が必要なページにエラーメッセージを全て表示するようにした。日本語で表示するように実装した。
#Why
どの入力が足りていなかったのか、間違っていたのかをユーザーがすぐにわかるようにするため。英語より日本語の方がよりわかりやすいため。